### PR TITLE
latexの実行にlatexmkを使う

### DIFF
--- a/alpsize/Makefile
+++ b/alpsize/Makefile
@@ -4,25 +4,21 @@ PLATEX = platex -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex

--- a/installation/Makefile
+++ b/installation/Makefile
@@ -4,25 +4,21 @@ PLATEX = platex -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex

--- a/matplotlib/Makefile
+++ b/matplotlib/Makefile
@@ -4,25 +4,21 @@ PLATEX = platex -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex

--- a/overview/Makefile
+++ b/overview/Makefile
@@ -1,38 +1,32 @@
 BASENAME = overview
-SRC = *.bb ../style/*.sty ../style/*.bb
-PLATEX   = platex -shell-escape -interaction=nonstopmode
+SRC = ${BASENAME}.tex ../style/*.sty ../style/*.bb
+PLATEX   = platex
 PDFLATEX = pdflatex
 TEXFLAGS = -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${BASENAME}.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX} ${TEXFLAGS}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
-
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${BASENAME}.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX} ${TEXFLAGS}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
 ${BASENAME}-en-wide.pdf: ${BASENAME}-en-wide.tex ${BASENAME}-en.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: latexmk -pdf -use-make -pdflatex="${PDFLATEX} ${TEXFLAGS}" ${BASENAME}-en-wide.tex
 
 ${BASENAME}-en-normal.pdf: ${BASENAME}-en-normal.tex ${BASENAME}-en.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: latexmk -pdf -use-make -pdflatex="${PDFLATEX} ${TEXFLAGS}" ${BASENAME}-en-normal.tex
+
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex ${BASENAME}-en-wide.tex ${BASENAME}-en-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex ${BASENAME}-en-wide.tex ${BASENAME}-en-normal.tex

--- a/overview/Makefile
+++ b/overview/Makefile
@@ -1,32 +1,34 @@
 BASENAME = overview
 SRC = *.bb ../style/*.sty ../style/*.bb
-PLATEX = platex -shell-escape -interaction=nonstopmode
+PLATEX   = platex -shell-escape -interaction=nonstopmode
+PDFLATEX = pdflatex
+TEXFLAGS = -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
 
 ${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${BASENAME}.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
 
 ${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
 	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
 
 ${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${BASENAME}.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
 
 ${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
 	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
 
 ${BASENAME}-en-wide.pdf: ${BASENAME}-en-wide.tex ${BASENAME}-en.tex ${SRC}
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
 
 ${BASENAME}-en-normal.pdf: ${BASENAME}-en-normal.tex ${BASENAME}-en.tex ${SRC}
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
 
 clean:
 	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb

--- a/pyalps/Makefile
+++ b/pyalps/Makefile
@@ -4,25 +4,21 @@ PLATEX = platex -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,28 +1,24 @@
 BASENAME = python
-SRC = ${BASENAME}.tex *.bb ../style/*.sty ../style/*.bb
+SRC = ${BASENAME}.tex ../style/*.sty ../style/*.bb
 PLATEX = platex -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC}
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -1,34 +1,36 @@
 BASENAME = tutorial
 SRC = ../style/*.sty ../style/*.bb
-PLATEX = platex -shell-escape -interaction=nonstopmode
+PLATEX   = platex
+PDFLATEX = pdflatex
+TEXFLAGS = -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
 
 ${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC} ${BASENAME}.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
 
 ${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
 	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
 
 ${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC} ${BASENAME}.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
+	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
 
 ${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
 	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
 
 ${BASENAME}-en-wide.pdf: ${BASENAME}-en-wide.tex ${SRC} ${BASENAME}-en.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
 
 ${BASENAME}-en-normal.pdf: ${BASENAME}-en-normal.tex ${SRC} ${BASENAME}-en.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: pdflatex -shell-escape ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
+	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
 
 clean:
 	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -1,40 +1,32 @@
 BASENAME = tutorial
-SRC = ../style/*.sty ../style/*.bb
+SRC = ${BASENAME}.tex ../style/*.sty ../style/*.bb
 PLATEX   = platex
 PDFLATEX = pdflatex
 TEXFLAGS = -shell-escape -interaction=nonstopmode
 
 default: ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
 
-${BASENAME}-wide.dvi: ${BASENAME}-wide.tex ${SRC} ${BASENAME}.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-wide.tex
+${BASENAME}-wide.pdf: ${BASENAME}-wide.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX} ${TEXFLAGS}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-wide.tex
 
-${BASENAME}-wide.pdf: ${BASENAME}-wide.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-wide.dvi
+${BASENAME}-normal.pdf: ${BASENAME}-normal.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdfdvi -use-make -latex="${PLATEX} ${TEXFLAGS}" \
+	 -e '$$dvipdf = "dvipdfmx %O -o %D %S"' \
+	 ${BASENAME}-normal.tex
 
-${BASENAME}-normal.dvi: ${BASENAME}-normal.tex ${SRC} ${BASENAME}.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
-	TEXINPUTS=.:../style//: ${PLATEX} ${TEXFLAGS} ${BASENAME}-normal.tex
+${BASENAME}-en-wide.pdf: ${BASENAME}-en-wide.tex ${BASENAME}-en.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdf -use-make -pdflatex="${PDFLATEX} ${TEXFLAGS}" ${BASENAME}-en-wide.tex
 
-${BASENAME}-normal.pdf: ${BASENAME}-normal.dvi
-	TEXINPUTS=.:../style//: dvipdfmx ${BASENAME}-normal.dvi
+${BASENAME}-en-normal.pdf: ${BASENAME}-en-normal.tex ${BASENAME}-en.tex ${SRC}
+	TEXINPUTS=.:../style//: latexmk -pdf -use-make -pdflatex="${PDFLATEX} ${TEXFLAGS}" ${BASENAME}-en-normal.tex
 
-${BASENAME}-en-wide.pdf: ${BASENAME}-en-wide.tex ${SRC} ${BASENAME}-en.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-wide.tex
-
-${BASENAME}-en-normal.pdf: ${BASENAME}-en-normal.tex ${SRC} ${BASENAME}-en.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
-	TEXINPUTS=.:../style//: ${PDFLATEX} ${TEXFLAGS} ${BASENAME}-en-normal.tex
+.sty:
 
 clean:
-	rm -f ${BASENAME}*.aux ${BASENAME}*.dvi ${BASENAME}*.log ${BASENAME}*.nav ${BASENAME}*.out ${BASENAME}*.snm ${BASENAME}*.toc ${BASENAME}*.vrb
-	rm -rf auto *.xbb ../style/*.xbb
+	@latexmk -c ${BASENAME}-wide.tex ${BASENAME}-normal.tex ${BASENAME}-en-wide.tex ${BASENAME}-en-normal.tex
+	@rm -f *.nav *.snm *.vrb
 
 distclean: clean
-	rm -f ${BASENAME}-wide.pdf ${BASENAME}-normal.pdf ${BASENAME}-en-wide.pdf ${BASENAME}-en-normal.pdf
+	@latexmk -C ${BASENAME}-wide.tex ${BASENAME}-normal.tex ${BASENAME}-en-wide.tex ${BASENAME}-en-normal.tex


### PR DESCRIPTION
最近のTeXディストリビューションに含まれているlatexmkを使ってビルドします。
Makefileが多少簡略化され、latexの実行回数(2回とか3回とか)を自動的に判定してくれます。

今回の変更では、latexの実行回数の削減はできず、コンパイル時間的にはあまり効果はありません。